### PR TITLE
Lean: centralize operating model and enforce Git-driven Pi bootstrap

### DIFF
--- a/.github/workflows/ci-shell-syntax-v1.yml
+++ b/.github/workflows/ci-shell-syntax-v1.yml
@@ -6,7 +6,6 @@ on:
       - main
       - dev/**
       - si/**
-      - temp_codex
   pull_request:
 
 jobs:

--- a/.github/workflows/component-test-deploy-v10.yml
+++ b/.github/workflows/component-test-deploy-v10.yml
@@ -46,17 +46,10 @@ jobs:
           ref: ${{ inputs.git_ref }}
           path: target_ref
 
-      - name: Preflight writable paths on runner host
+      - name: Bootstrap Pi dependencies and paths (repo-controlled)
         shell: bash
         run: |
-          mkdir -p /opt/scale-radio/state
-          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
-          mkdir -p /data/plugins/user_interface
-          mkdir -p /data/configuration/user_interface
-          test -w /opt/scale-radio/state
-          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
-          test -w /data/plugins/user_interface
-          test -w /data/configuration/user_interface
+          bash tools/deploy/pi-bootstrap-v1.sh deploy
 
       - name: Acquire target deploy slot
         id: acquire_slot

--- a/.github/workflows/component-test-release-slot-v3.yml
+++ b/.github/workflows/component-test-release-slot-v3.yml
@@ -41,11 +41,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Preflight writable paths on runner host
+      - name: Bootstrap Pi state path (repo-controlled)
         shell: bash
         run: |
-          mkdir -p /opt/scale-radio/state
-          test -w /opt/scale-radio/state
+          bash tools/deploy/pi-bootstrap-v1.sh state
 
       - name: Release target test slot
         shell: bash

--- a/.github/workflows/component-test-rollback-v10.yml
+++ b/.github/workflows/component-test-rollback-v10.yml
@@ -42,13 +42,10 @@ jobs:
           ref: ${{ inputs.git_ref }}
           path: target_ref
 
-      - name: Preflight writable paths on runner host
+      - name: Bootstrap Pi dependencies and paths (repo-controlled)
         shell: bash
         run: |
-          mkdir -p /opt/scale-radio/state
-          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
-          test -w /opt/scale-radio/state
-          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
+          bash tools/deploy/pi-bootstrap-v1.sh deploy
 
       - name: Acquire target rollback slot
         id: acquire_slot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,17 +3,14 @@
 ## Scope
 This file applies to the whole repository.
 
-## Operating rules (mandatory)
-1. Work from Git branches only (`main`, `dev/*`, `si/*`, `temp_codex`).
-2. Never use local-only branch `work`.
-3. Push branch changes to `origin` before reporting completion.
-4. `main` is protected truth; changes land through PR.
-5. Keep repository docs minimal and aligned to the RadioScale operating model.
-6. Remove stale/legacy markdown surfaces when they are not execution-relevant.
-7. If blocked, report exact blocker and required owner decision in one line.
+## Central operating truth
+- Canonical operating model: `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`.
+- Do not restate or fork operating doctrine in local docs.
 
-## Branch intent
-- `main`: accepted stable truth
-- `dev/*`: active component implementation
-- `si/*`: orchestration and cross-component control-plane updates
-- `temp_codex`: temporary integration lane for consolidation work
+## Mandatory execution rules
+1. Use Git branches only (`main`, `dev/*`, `si/*`).
+2. `si/*` is governance-only (contracts/process/docs). Product development runs on `dev/*`.
+3. Never use local-only branch `work`.
+4. Push branch changes to `origin` before reporting completion.
+5. `main` is protected truth; land changes through PR.
+6. If blocked, report one explicit blocker and the one owner decision needed.

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -1,0 +1,8 @@
+# Component AGENTS
+
+Component work follows the central operating model:
+- `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`
+- `AGENTS.md` (repo root)
+
+Local component notes belong only in component README/runtime files.
+Do not define local operating-model variants here.

--- a/components/scale-radio-autoswitch/AGENTS.md
+++ b/components/scale-radio-autoswitch/AGENTS.md
@@ -1,0 +1,7 @@
+# Component Agent Notes
+
+Use central operating truth only:
+- `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`
+- `AGENTS.md` (repo root)
+
+No local workflow/governance/branch/status doctrine is defined here.

--- a/components/scale-radio-bridge/AGENTS.md
+++ b/components/scale-radio-bridge/AGENTS.md
@@ -1,0 +1,7 @@
+# Component Agent Notes
+
+Use central operating truth only:
+- `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`
+- `AGENTS.md` (repo root)
+
+No local workflow/governance/branch/status doctrine is defined here.

--- a/components/scale-radio-faceplate/AGENTS.md
+++ b/components/scale-radio-faceplate/AGENTS.md
@@ -1,0 +1,7 @@
+# Component Agent Notes
+
+Use central operating truth only:
+- `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`
+- `AGENTS.md` (repo root)
+
+No local workflow/governance/branch/status doctrine is defined here.

--- a/components/scale-radio-fun-line/AGENTS.md
+++ b/components/scale-radio-fun-line/AGENTS.md
@@ -1,0 +1,7 @@
+# Component Agent Notes
+
+Use central operating truth only:
+- `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`
+- `AGENTS.md` (repo root)
+
+No local workflow/governance/branch/status doctrine is defined here.

--- a/components/scale-radio-hardware/AGENTS.md
+++ b/components/scale-radio-hardware/AGENTS.md
@@ -1,0 +1,7 @@
+# Component Agent Notes
+
+Use central operating truth only:
+- `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`
+- `AGENTS.md` (repo root)
+
+No local workflow/governance/branch/status doctrine is defined here.

--- a/components/scale-radio-starter/AGENTS.md
+++ b/components/scale-radio-starter/AGENTS.md
@@ -1,0 +1,7 @@
+# Component Agent Notes
+
+Use central operating truth only:
+- `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`
+- `AGENTS.md` (repo root)
+
+No local workflow/governance/branch/status doctrine is defined here.

--- a/components/scale-radio-tuner/AGENTS.md
+++ b/components/scale-radio-tuner/AGENTS.md
@@ -1,0 +1,7 @@
+# Component Agent Notes
+
+Use central operating truth only:
+- `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`
+- `AGENTS.md` (repo root)
+
+No local workflow/governance/branch/status doctrine is defined here.

--- a/contracts/STARTVERSION_contract_stack_v1.md
+++ b/contracts/STARTVERSION_contract_stack_v1.md
@@ -1,10 +1,12 @@
 # STARTVERSION Contract Stack v1
 
 ## Purpose
-Minimum RadioScale operating contracts for deterministic, auditable, low-admin execution.
+Minimum RadioScale contract set for deterministic, auditable, low-admin execution.
 
-## Active contracts (only)
+## Canonical operating source
 - `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`
+
+## Active contracts
 - `contracts/deployment/STARTVERSION_deployment_contract_v1.md`
 - `contracts/coding/STARTVERSION_coding_contract_v1.md`
 - `contracts/gui/STARTVERSION_gui_contract_v1.md`
@@ -15,14 +17,12 @@ Minimum RadioScale operating contracts for deterministic, auditable, low-admin e
 - `contracts/integrations/chatgpt_v1.md`
 
 ## Conflict rule
-1. More specific STARTVERSION contract wins.
-2. If still unclear, escalate once to owner.
+1. Repo operating contract is the root authority.
+2. More specific contract wins if not conflicting.
+3. If still unclear, escalate once to owner.
 
 ## PR minimum
 - scope summary
 - executed checks
 - rollback command
 - owner decision (`accept | changes-requested | reject`)
-
-## Owner one-click surface
-- `reports/owner/dashboard_v1.html`

--- a/contracts/deployment/STARTVERSION_deployment_contract_v1.md
+++ b/contracts/deployment/STARTVERSION_deployment_contract_v1.md
@@ -1,20 +1,26 @@
 # STARTVERSION Deployment Contract v1
 
 ## Objective
-Ship safely with minimal ceremony.
+Ship safely with minimal ceremony through repo-controlled automation.
+
+## Mandatory deployment surface
+- Standard delivery is GitHub workflow + repo deploy scripts.
+- Manual Pi shell install/fix steps are not accepted as normal workflow.
 
 ## 1) Pre-deploy requirements
-- Build/runtime checks pass for changed component(s).
+- Checks pass for changed component(s).
 - Deploy target and release identifier are explicit.
 - Rollback target is explicit.
 
 ## 2) Deployment execution
 - One active deployment target slot at a time per target environment.
-- Run deploy steps deterministically from repo-truth artifacts.
+- Pi bootstrap runs from repo script before deploy/rollback.
+- Deploy steps run deterministically from repository artifacts.
+- Re-running bootstrap/deploy must be idempotent.
 - Record deployed version and timestamp.
 
 ## 3) Rollback requirements
-- Every deployable release must have one tested rollback path.
+- Every deployable release has one repo-controlled rollback path.
 - Rollback command must be included in PR packet.
 
 ## 4) Promotion gate to `main`
@@ -24,8 +30,12 @@ A release is merge-ready only when:
 - owner decision captured.
 
 ## 5) Git automation baseline (required)
-- `ci-shell-syntax-v1` must run on push/PR for script syntax guardrails.
-- `component-test-deploy-v10` is the canonical deploy test entrypoint.
+- `ci-shell-syntax-v1` is required on push/PR.
+- `component-test-deploy-v10` is the canonical deploy entrypoint.
 - `component-test-rollback-v10` is the canonical rollback entrypoint.
 - `component-test-release-slot-v3` is the canonical slot release entrypoint.
-- Deploy/rollback workflows are run as `workflow_dispatch` with explicit `component`, `git_ref`, `payload`, and `target`.
+- Deploy/rollback workflows run as `workflow_dispatch` with explicit `component`, `git_ref`, `payload`, and `target`.
+- Workflows must run `tools/deploy/pi-bootstrap-v1.sh` so dependencies/setup stay repo-controlled.
+
+## 6) Manual dependency drift policy
+If deployment still requires manual dependency installation on Pi, treat that as a blocker and absorb it into repo bootstrap scripts/workflows.

--- a/contracts/integrations/chatgpt_v1.md
+++ b/contracts/integrations/chatgpt_v1.md
@@ -1,25 +1,30 @@
 # ChatGPT/Codex Intake Contract v1 (RadioScale)
 
 ## Purpose
-Define minimal, deterministic intake/routing for owner + ChatGPT + Codex.
+Define lightweight intake from owner/ChatGPT into Codex execution.
 
-## Truth order
-1. repo contracts
-2. branch commits and PR state
-3. issue state/comments
+## Source of truth
+- Operating doctrine and statuses are defined only in `contracts/repo/STARTVERSION_repo_operating_contract_v1.md`.
+- This file defines intake interface only.
 
 ## Intake sources
 - owner direct in Codex chat
-- JSON handover in `handoff/open/`
+- one JSON handover file in `handoff/open/`
 
-## Routing model
-- Codex maps each request to target branch/component.
-- One intake may contain multiple component requests.
-- Statuses: `backlog`, `open`, `in_progress`, `on_hold`, `done`.
+## Intake payload rule
+- One handover JSON may contain multiple requests.
+- Codex decides target component branch mapping.
 
-## Done evidence (required)
-- `test_evidence`
-- `rollback_evidence`
+## Request minimum fields
+- `id`
+- `component` or `components`
+- `summary`
+- `constraints`
+- `acceptance`
+- `depends_on`
+- `deploy_required`
+- `test_required`
+- `asset_refs`
 
 ## Constraints
 - no fake delivery

--- a/contracts/repo/STARTVERSION_repo_operating_contract_v1.md
+++ b/contracts/repo/STARTVERSION_repo_operating_contract_v1.md
@@ -1,26 +1,41 @@
 # STARTVERSION Repo Operating Contract v1
 
+## Single operating-model truth
+This file is the canonical operating model for RadioScale.
+Other docs may link to this file but must not redefine branch doctrine, status doctrine, or handover doctrine.
+
 ## Truth and branches
 - `main` is the only accepted truth.
 - No direct commits to `main`; PR required.
-- Working branches: `dev/*`, `si/*`, `temp_codex`.
-- Branch `work` is forbidden.
+- Product development branches: `dev/*`.
+- Optional UX lane: `dev/ux`.
+- Governance-only lane: `si/*` (governance contracts/process docs only, not normal product implementation).
+- Branch `work` and temporary integration lanes are invalid.
 
 ## Git-only execution
-- Every agent must work on a Git-tracked branch and push before reporting done.
+- Every agent works on a Git-tracked branch and pushes before reporting done.
 - Local-only completion claims are invalid.
 
-## Delivery model
-- One package may cover multiple components.
-- Codex owns technical split and routing.
-- Keep docs and artifacts minimal; remove stale markdown/process noise.
+## Lean delivery model
+- One package may include multiple components.
+- Codex determines technical split per component branch.
+- Handover is lightweight input; repo state + PR evidence is truth.
+- Keep docs minimal; delete stale/duplicate operating text.
 
 ## Status model
 Allowed statuses: `backlog`, `open`, `in_progress`, `on_hold`, `done`.
 
-## Done evidence
+## Done evidence (required)
 - `test_evidence`
 - `rollback_evidence`
+
+## Deploy-to-Pi operating rule (mandatory)
+- Standard path is Git-driven deploy/rollback via repo workflows and scripts.
+- Routine deployment must not require manual Pi shell install/fix steps.
+- Runtime dependencies, setup actions, permissions, and service actions must be handled by repo-controlled bootstrap/deploy scripts.
+- Deploy scripts must be idempotent.
+- Rollback must remain repo-controlled.
+- Any remaining manual Pi prerequisite is a blocker to eliminate, not an accepted normal step.
 
 ## Non-negotiables
 - no fake delivery

--- a/docs/operations/autodeploy_and_rollout_v1.md
+++ b/docs/operations/autodeploy_and_rollout_v1.md
@@ -1,24 +1,33 @@
 # RadioScale Autodeploy and Rollout v1
 
+## Standard operating rule
+Deploy and rollback to the Pi are Git-driven and repo-controlled.
+Manual Pi shell install/fix steps are not part of normal delivery.
+
 ## Active workflows
 - `.github/workflows/ci-shell-syntax-v1.yml`
 - `.github/workflows/component-test-deploy-v10.yml`
 - `.github/workflows/component-test-rollback-v10.yml`
 - `.github/workflows/component-test-release-slot-v3.yml`
 
-## Deploy support matrix
+## Supported components
 - `tuner`
 - `fun-line`
 - `bridge`
 
 ## Execution path
-1. Implement on branch (`dev/*` or `si/*`).
+1. Implement on component branch (`dev/*`).
 2. Open PR and pass CI shell syntax check.
-3. Run deploy workflow (target + component + git_ref + payload).
+3. Run deploy workflow with explicit `target`, `component`, `git_ref`, and `payload`.
 4. Validate runtime.
 5. Run rollback workflow when required.
-6. Release slot.
+6. Release target slot.
 7. Merge after owner acceptance.
+
+## Repo-controlled Pi bootstrap
+- Workflow bootstrap step runs `tools/deploy/pi-bootstrap-v1.sh` before deploy/rollback.
+- Bootstrap installs missing runtime dependencies and creates required directories idempotently.
+- Any bootstrap failure is a blocker and must be fixed in repo scripts/workflows.
 
 ## Required evidence
 - deploy run URL

--- a/reports/owner/dashboard_v1.html
+++ b/reports/owner/dashboard_v1.html
@@ -43,7 +43,7 @@
       </div>
 
       <div class="card">
-        <h3>Governance & Contracts</h3>
+        <h3>Contracts</h3>
         <ul>
           <li><a href="../../contracts/STARTVERSION_contract_stack_v1.md">STARTVERSION Contract Stack</a></li>
           <li><a href="../../contracts/repo/STARTVERSION_repo_operating_contract_v1.md">Repo Operating Contract</a></li>
@@ -52,7 +52,7 @@
       </div>
     </div>
 
-    <p style="margin-top:16px;">Truth rule: <code>main</code> is accepted truth. Development happens on <code>dev/*</code> or scoped <code>si/*</code> branches.</p>
+    <p style="margin-top:16px;">Truth rule: <code>main</code> is accepted truth. Development runs on <code>dev/*</code>; <code>si/*</code> is governance-only.</p>
   </div>
 </body>
 </html>

--- a/tools/deploy/pi-bootstrap-v1.sh
+++ b/tools/deploy/pi-bootstrap-v1.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="${1:-deploy}"
+
+run_sudo() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+    return
+  fi
+
+  if [[ -n "${PI_SUDO_PASSWORD:-}" ]]; then
+    printf '%s
+' "$PI_SUDO_PASSWORD" | sudo -S -p '' "$@"
+  else
+    sudo -n "$@"
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "RS_BOOTSTRAP: required command missing: $cmd" >&2
+    return 1
+  fi
+}
+
+install_missing_packages() {
+  local missing=()
+  for p in "$@"; do
+    if ! dpkg -s "$p" >/dev/null 2>&1; then
+      missing+=("$p")
+    fi
+  done
+
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    echo "RS_BOOTSTRAP: apt packages already satisfied"
+    return 0
+  fi
+
+  echo "RS_BOOTSTRAP: installing missing apt packages: ${missing[*]}"
+  run_sudo apt-get update -y
+  run_sudo DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing[@]}"
+}
+
+if [[ "$PROFILE" != "deploy" && "$PROFILE" != "state" ]]; then
+  echo "Usage: pi-bootstrap-v1.sh [deploy|state]" >&2
+  exit 2
+fi
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "RS_BOOTSTRAP: apt-get not available; cannot guarantee repo-controlled dependency setup" >&2
+  exit 2
+fi
+
+install_missing_packages bash coreutils curl jq python3
+
+if [[ "$PROFILE" == "deploy" ]]; then
+  install_missing_packages nodejs npm
+  require_cmd systemctl
+fi
+
+run_sudo mkdir -p /opt/scale-radio/state
+run_sudo mkdir -p /opt/scale-radio/removed/tuner
+run_sudo mkdir -p /opt/scale-radio/removed/bridge
+run_sudo mkdir -p /opt/scale-radio/removed/fun-line
+
+if [[ "$PROFILE" == "deploy" ]]; then
+  run_sudo mkdir -p /data/plugins/user_interface
+  run_sudo mkdir -p /data/configuration/user_interface
+fi
+
+if id -u volumio >/dev/null 2>&1; then
+  run_sudo chown -R volumio:volumio /opt/scale-radio/state /opt/scale-radio/removed || true
+fi
+
+echo "RS_BOOTSTRAP: complete (profile=$PROFILE)"


### PR DESCRIPTION
## Summary
- Centralized operating doctrine into one canonical source.
- Restricted `si/*` to governance-only and removed temporary branch lane references.
- Reduced component-level AGENTS to central pointers only.
- Enforced Git-driven Pi deploy with repo-controlled idempotent bootstrap.

## Validation
- `bash tools/ci/check_shell_syntax_v3.sh`
- `rg -n "temp_codex|temp_chatgpt" AGENTS.md contracts docs reports .github tools components`
- `rg -n "dev/\*|si/\*" AGENTS.md contracts docs reports`
