### PR TITLE
Fix intake trigger: schedule archive polling from main workflow

### DIFF
--- a/.github/workflows/archive-handoff-auto-route-v1.yml
+++ b/.github/workflows/archive-handoff-auto-route-v1.yml
@@ -1,11 +1,12 @@
 name: archive-handoff-auto-route-v1
 
 on:
+  schedule:
+    - cron: '*/5 * * * *'
   push:
     branches:
-      - ops/chat-archive
-    paths:
-      - handoff/open/*.json
+      - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -15,7 +16,7 @@ jobs:
   route-handoff:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/contracts/integrations/chatgpt_v1.md
+++ b/contracts/integrations/chatgpt_v1.md
@@ -23,4 +23,4 @@ Operating rules live only in `contracts/operating_model_v1.md`.
 - archive branch content is input/archive only, never product truth
 - owner does not shuttle files between branches
 - Codex maps intake into `dev/*` implementation branches
-- push to `ops/chat-archive` (`handoff/open/*.json`) auto-triggers routing + issue creation via `.github/workflows/archive-handoff-auto-route-v1.yml`
+- scheduled workflow `.github/workflows/archive-handoff-auto-route-v1.yml` pulls `ops/chat-archive` handoff files and auto-creates routing issues

--- a/contracts/operating_model_v1.md
+++ b/contracts/operating_model_v1.md
@@ -14,7 +14,7 @@ This is the single operating-model truth for this repository.
 - One package may touch multiple components.
 - Owner can hand over directly in Codex chat.
 - Optional file handoff exists on `ops/chat-archive`.
-- Push to `ops/chat-archive` (`handoff/open/*.json`) auto-routes intake; no manual workflow click is required.
+- Archive intake is auto-routed from `ops/chat-archive` by scheduled workflow (`archive-handoff-auto-route-v1`); no manual workflow click is required.
 - Owner does not manually move handoff files between branches.
 - Codex bridges archive intake into implementation flow.
 


### PR DESCRIPTION
Fixes missing intake trigger: workflow now runs from main on schedule and polls ops/chat-archive for handoff/open JSON.