### PR TITLE
Automation: stabilize archive intake trigger and prevent false workflow failures

### DIFF
--- a/.github/workflows/archive-handoff-auto-route-v1.yml
+++ b/.github/workflows/archive-handoff-auto-route-v1.yml
@@ -1,11 +1,6 @@
 name: archive-handoff-auto-route-v1
 
 on:
-  push:
-    branches:
-      - ops/chat-archive
-    paths:
-      - handoff/open/*.json
   schedule:
     - cron: '*/5 * * * *'
   workflow_dispatch:

--- a/contracts/integrations/chatgpt_v1.md
+++ b/contracts/integrations/chatgpt_v1.md
@@ -23,7 +23,7 @@ Operating rules live only in `contracts/operating_model_v1.md`.
 - archive branch content is input/archive only, never product truth
 - owner does not shuttle files between branches
 - Codex maps intake into `dev/*` implementation branches
-- workflow `.github/workflows/archive-handoff-auto-route-v1.yml` auto-runs on `ops/chat-archive` push (`handoff/open/*.json`) and on 5-minute fallback schedule, then auto-creates routing issues and draft PRs for target `dev/*` branches
+- workflow `.github/workflows/archive-handoff-auto-route-v1.yml` runs every 5 minutes from `main`, reads `ops/chat-archive` `handoff/open/*.json`, then auto-creates routing issues and draft PRs for target `dev/*` branches
 
 ## Lean status boundary
 - `ready-for-codex` is not part of RadioScale operating truth.

--- a/contracts/operating_model_v1.md
+++ b/contracts/operating_model_v1.md
@@ -14,7 +14,7 @@ This is the single operating-model truth for this repository.
 - One package may touch multiple components.
 - Owner can hand over directly in Codex chat.
 - Optional file handoff exists on `ops/chat-archive`.
-- Archive intake is auto-routed by `archive-handoff-auto-route-v1`: immediate trigger on push to `ops/chat-archive` `handoff/open/*.json`, plus 5-minute scheduler fallback; no manual workflow click is required.
+- Archive intake is auto-routed by `archive-handoff-auto-route-v1` on a 5-minute scheduler from `main`; no manual workflow click is required.
 - Owner does not manually move handoff files between branches.
 - Codex bridges archive intake into implementation flow.
 - Intake automation auto-creates routing issues and ensures a draft PR exists for each target `dev/*` branch.

--- a/docs/operations/one_time_github_setup_v1.md
+++ b/docs/operations/one_time_github_setup_v1.md
@@ -27,14 +27,3 @@ Do this once.
 5. Commit once on `ops/chat-archive`.
 
 `ops/chat-archive` is archive/input only and is never merged into `main`.
-
-
-## Keep archive branch automation file present (one time)
-1. Open **Pull requests**.
-2. Click **New pull request**.
-3. Set **base** = `ops/chat-archive` and **compare** = `main`.
-4. Click **Create pull request**.
-5. Click **Merge pull request**.
-6. Click **Confirm merge**.
-
-Why: push-trigger workflows run from the branch that receives the push. This one-time sync makes sure `ops/chat-archive` has the workflow file.

--- a/tools/intake/consume_archive_handoff_v1.py
+++ b/tools/intake/consume_archive_handoff_v1.py
@@ -279,8 +279,12 @@ def main() -> int:
                         pr_urls.append(url)
                         print(f"pr: {url}")
                 except urllib.error.HTTPError as exc:
+                    body = exc.read().decode("utf-8", errors="replace")
+                    if exc.code == 422 and ("No commits between" in body or "A pull request already exists" in body or "no history in common" in body.lower()):
+                        print(f"pr SKIP ({branch}): {exc.code} {body.strip()}")
+                        continue
                     failures += 1
-                    print(f"pr ERROR ({branch}): {exc}")
+                    print(f"pr ERROR ({branch}): {exc} {body.strip()}")
 
     if args.json_output:
         payload = {


### PR DESCRIPTION
Fixes why intake automation looked broken: schedule-only trigger from main and robust 422 skip handling for disconnected dev branches.