### PR TITLE
Deploy: autodeploy to Pi from supported dev branches on push

### DIFF
--- a/.github/workflows/dev-autodeploy-on-push-v1.yml
+++ b/.github/workflows/dev-autodeploy-on-push-v1.yml
@@ -1,0 +1,108 @@
+name: dev-autodeploy-on-push-v1
+
+on:
+  push:
+    branches:
+      - dev/tuner
+      - dev/bridge
+      - dev/fun-line
+    paths:
+      - 'components/**'
+      - 'tools/deploy/**'
+      - '.github/workflows/dev-autodeploy-on-push-v1.yml'
+  workflow_dispatch:
+    inputs:
+      branch_ref:
+        description: "Branch ref to deploy (defaults to triggering ref)"
+        required: false
+        default: ""
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      test_hold_minutes:
+        description: "Minutes to reserve slot for testing"
+        required: true
+        default: "120"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: radioscale-${{ github.event.inputs.target || 'primary' }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  autodeploy:
+    runs-on: [self-hosted, radioscale, pi]
+    env:
+      PI_SUDO_PASSWORD: ${{ secrets.PI_SUDO_PASSWORD }}
+      REF_NAME: ${{ github.event.inputs.branch_ref || github.ref_name }}
+      TARGET_SLOT: ${{ github.event.inputs.target || 'primary' }}
+      HOLD_MINUTES: ${{ github.event.inputs.test_hold_minutes || '120' }}
+    steps:
+      - name: Resolve component from branch
+        id: resolve
+        shell: bash
+        run: |
+          ref="${REF_NAME#refs/heads/}"
+          case "$ref" in
+            dev/tuner) component="tuner" ;;
+            dev/bridge) component="bridge" ;;
+            dev/fun-line) component="fun-line" ;;
+            *)
+              echo "Unsupported autodeploy branch: $ref"
+              exit 2
+              ;;
+          esac
+          echo "component=$component" >> "$GITHUB_OUTPUT"
+          echo "branch_ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout selected dev branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.resolve.outputs.branch_ref }}
+
+      - name: Bootstrap Pi dependencies and paths (repo-controlled)
+        shell: bash
+        run: |
+          bash tools/deploy/pi-bootstrap-v1.sh deploy
+
+      - name: Acquire target deploy slot
+        id: acquire_slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh acquire-deploy "${TARGET_SLOT}" "${{ steps.resolve.outputs.component }}" "${{ steps.resolve.outputs.branch_ref }}" "current_dev" "autodeploy:${GITHUB_RUN_ID}" "${HOLD_MINUTES}"
+
+      - name: Deploy selected component payload
+        id: apply_payload
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper-v3.sh deploy "${{ steps.resolve.outputs.component }}" "current_dev" "$GITHUB_WORKSPACE"
+
+      - name: Mark target slot as test_open
+        if: success()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh mark-test-open "${TARGET_SLOT}" "${{ steps.resolve.outputs.component }}" "${{ steps.resolve.outputs.branch_ref }}" "current_dev" "autodeploy:${GITHUB_RUN_ID}" "${HOLD_MINUTES}"
+
+      - name: Roll back selected payload on failure
+        id: rollback_on_failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh acquire-rollback "${TARGET_SLOT}" "${{ steps.resolve.outputs.component }}" "${{ steps.resolve.outputs.branch_ref }}" "current_dev" "autodeploy-failure-rollback:${GITHUB_RUN_ID}"
+          bash tools/deploy/sr-deploy-wrapper-v3.sh rollback "${{ steps.resolve.outputs.component }}" "current_dev" "$GITHUB_WORKSPACE"
+
+      - name: Release target slot after successful failure rollback
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome == 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh release "${TARGET_SLOT}" "${{ steps.resolve.outputs.component }}" "${{ steps.resolve.outputs.branch_ref }}" "current_dev" "autodeploy-failure-rollback:${GITHUB_RUN_ID}" "deploy_failed_rollback_completed"
+
+      - name: Mark target slot blocked when deploy/rollback did not complete cleanly
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome != 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh mark-blocked "${TARGET_SLOT}" "${{ steps.resolve.outputs.component }}" "${{ steps.resolve.outputs.branch_ref }}" "current_dev" "autodeploy:${GITHUB_RUN_ID}" "deploy_or_failure_rollback_incomplete"

--- a/.github/workflows/issue-autostart-v1.yml
+++ b/.github/workflows/issue-autostart-v1.yml
@@ -10,21 +10,42 @@ permissions:
 
 jobs:
   autostart:
-    if: contains(github.event.issue.labels.*.name, 'status/open') || contains(github.event.issue.labels.*.name, 'status/backlog')
+    if: startsWith(github.event.issue.title, '[handoff]')
     runs-on: ubuntu-latest
     steps:
-      - name: Move issue to in_progress and stamp autostart
+      - name: Move handoff issue to in_progress and stamp autostart
         uses: actions/github-script@v7
         with:
           script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
             const issue = context.payload.issue;
-            const labels = issue.labels.map(l => l.name).filter(n => n !== 'status/open' && n !== 'status/backlog');
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                } else {
+                  throw e;
+                }
+              }
+            }
+
+            await ensureLabel('status/open', '0052cc', 'Issue ready for execution.');
+            await ensureLabel('status/in_progress', 'fbca04', 'Issue currently being executed.');
+            await ensureLabel('source/handoff', '0e8a16', 'Created from archive handoff intake.');
+
+            const existing = issue.labels.map(l => l.name);
+            const labels = existing.filter(n => n !== 'status/open' && n !== 'status/backlog');
             if (!labels.includes('status/in_progress')) labels.push('status/in_progress');
+            if (!labels.includes('source/handoff')) labels.push('source/handoff');
 
             try {
               await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner,
+                repo,
                 issue_number: issue.number,
                 labels
               });
@@ -32,11 +53,11 @@ jobs:
               core.warning(`label update skipped: ${e.message}`);
             }
 
-            const componentMatch = issue.body ? issue.body.match(/component:\s*`([^`]+)`/i) : null;
-            const target = componentMatch ? `dev/${componentMatch[1].trim()}` : 'dev/<component>';
+            const branchMatch = issue.title.match(/->\s*(dev\/[^\s`]+)/i);
+            const target = branchMatch ? branchMatch[1] : 'dev/<component>';
             await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               issue_number: issue.number,
-              body: `Autostart: development queued immediately.\\n\\nTarget branch: \\`${target}\\`\\nSource: issue #${issue.number}`
+              body: `Autostart: development queued immediately.\n\nTarget branch: \`${target}\`\nSource: issue #${issue.number}`
             });

--- a/contracts/operating_model_v1.md
+++ b/contracts/operating_model_v1.md
@@ -11,6 +11,7 @@ This is the single operating-model truth for this repository.
 
 ## Delivery model
 - Codex develops on `dev/*`, tests, and prepares PRs to `main`.
+- Commits on supported delivery branches (`dev/tuner`, `dev/bridge`, `dev/fun-line`) trigger repo-controlled Pi autodeploy from that branch (`dev-autodeploy-on-push-v1`).
 - One package may touch multiple components.
 - Owner can hand over directly in Codex chat.
 - Optional file handoff exists on `ops/chat-archive`.

--- a/docs/operations/autodeploy_and_rollout_v1.md
+++ b/docs/operations/autodeploy_and_rollout_v1.md
@@ -4,10 +4,12 @@ Operating model reference: `contracts/operating_model_v1.md`.
 
 ## Standard rule
 Deploy and rollback to Pi are Git-driven and repo-controlled.
+Commits on `dev/tuner`, `dev/bridge`, and `dev/fun-line` auto-trigger deploy to Pi from that branch via `dev-autodeploy-on-push-v1`.
 Manual Pi shell install/fix is not normal delivery.
 
 ## Active workflows
-- `.github/workflows/component-test-deploy-v10.yml`
+- `.github/workflows/dev-autodeploy-on-push-v1.yml` (automatic deploy on push for `dev/tuner`, `dev/bridge`, `dev/fun-line`)
+- `.github/workflows/component-test-deploy-v10.yml` (manual/explicit deploy run)
 - `.github/workflows/component-test-rollback-v10.yml`
 - `.github/workflows/component-test-release-slot-v3.yml`
 


### PR DESCRIPTION
Adds automatic Pi deploy on push for dev/tuner, dev/bridge, dev/fun-line and updates operating/deploy docs accordingly.