### PR TITLE
Tuner: stabilize slider middle-state activation

### DIFF
--- a/components/scale-radio-tuner/payload/current/config.json
+++ b/components/scale-radio-tuner/payload/current/config.json
@@ -160,7 +160,7 @@
     "type": "boolean"
   },
   "stationActivationDebounceMs": {
-    "value": 50,
+    "value": 110,
     "type": "number"
   },
   "stationActivationCooldownMs": {

--- a/components/scale-radio-tuner/payload/current/index.js
+++ b/components/scale-radio-tuner/payload/current/index.js
@@ -2938,7 +2938,9 @@ ControllerRadioScalePeppy.prototype.scheduleLockedStationActivation = function (
 
   this.clearPendingActivation();
 
-  const debounceMs = Math.max(25, Math.min(90, this.getNumberConfig('stationActivationDebounceMs', 50)));
+  // Keep activation stable around slider middle transitions: a longer debounce
+  // avoids rapid lock/unlock re-fires while the pointer settles.
+  const debounceMs = Math.max(40, Math.min(220, this.getNumberConfig('stationActivationDebounceMs', 110)));
   this.tuning.pendingActivation = {
     key: station.key,
     scheduledAt: Date.now(),


### PR DESCRIPTION
Implements immediate tuner development output: increases and clamps activation debounce to stabilize middle slider transitions and reduce rapid lock/unlock re-fires.